### PR TITLE
fix: quita IVA del crud porque ya no existe el modelo

### DIFF
--- a/src/templates/administracion/base.html
+++ b/src/templates/administracion/base.html
@@ -49,7 +49,6 @@
                         <a href="{% url 'listado-genero' %}" class="dropdown-item">Genero</a>
                         <a href="{% url 'listado-editorial' %}" class="dropdown-item">Editorial</a>
                         <a href="{% url 'listado-pais' %}" class="dropdown-item">Pais</a>
-                        <a href="{% url 'listado-iva' %}" class="dropdown-item">IVA</a>
                     </div>
                 </li>
 


### PR DESCRIPTION
Esto provocaba que cualquier página que extendiera administración se rompiera, lo que incluye el dashboard y todos los cruds