### PR TITLE
Crud ventas

### DIFF
--- a/src/artemangaweb/urls.py
+++ b/src/artemangaweb/urls.py
@@ -22,5 +22,4 @@ urlpatterns = [
     path('inventario/', include('inventario.urls')),
     path('cuenta-usuario/', include('cuenta_usuario.urls')),
     path('cuenta-usuario/', include('django.contrib.auth.urls')),
-
 ]

--- a/src/catalogo/urls.py
+++ b/src/catalogo/urls.py
@@ -2,6 +2,5 @@ from django.urls import path
 from .views import Home
 
 urlpatterns = [
-    path('', Home.as_view(), name='Home'),
-
+    path('', Home.as_view(), name='home'),
 ]

--- a/src/inventario/forms.py
+++ b/src/inventario/forms.py
@@ -17,3 +17,9 @@ class ProductoBodegaForm(forms.ModelForm):
     class Meta:
         model = Producto
         exclude = ['es_destacado', 'esta_publicado']
+
+
+class ActualizarProductoVentasForm(forms.ModelForm):
+    class Meta:
+        model = Producto
+        fields = ['es_destacado', 'esta_publicado', 'precio']

--- a/src/inventario/templates/CRUD/_listado_base.html
+++ b/src/inventario/templates/CRUD/_listado_base.html
@@ -10,25 +10,7 @@
     </table>
 
     {% block paginacion %}
-        <nav aria-label="Paginación">
-            {% if is_paginated %}
-                <ul class="pagination justify-content-center">
-                    {% if page_obj.has_previous %}
-                        <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Anterior</a></li>
-                    {% endif %}
-
-                    {% for i in paginator.page_range %}
-                        <li class="page-item {% if page_obj.number == i %}active{% endif %}">
-                            <a class="page-link" href="?page={{ i }}">{{ i }}</a>
-                        </li>
-                    {% endfor %}
-
-                    {% if page_obj.has_next %}
-                        <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number  }}">Siguiente</a></li>
-                    {% endif %}
-                </ul>
-            {% endif %}
-        </nav>
+        {% include 'común/includes/paginación.html' %}
     {% endblock %}
 
 {% endblock %}

--- a/src/inventario/templates/CRUD/_listado_base.html
+++ b/src/inventario/templates/CRUD/_listado_base.html
@@ -1,4 +1,4 @@
-{% extends 'administracion/base.html' %}
+{% extends 'administración/base.html' %}
 
 {% block contenido %}
     <a class="btn btn-success btn-lg btn-block" href="{% url url_crear  %}">Crear</a>

--- a/src/inventario/templates/CRUD/eliminar_generico.html
+++ b/src/inventario/templates/CRUD/eliminar_generico.html
@@ -1,4 +1,4 @@
-{% extends 'administracion/base.html' %}
+{% extends 'administración/base.html' %}
 {% load crispy_forms_filters %}
 
 {% block contenido %}

--- a/src/inventario/templates/CRUD/form_generico.html
+++ b/src/inventario/templates/CRUD/form_generico.html
@@ -1,4 +1,4 @@
-{% extends 'administracion/base.html' %}
+{% extends 'administración/base.html' %}
 
 {% load crispy_forms_filters %}
 

--- a/src/inventario/templates/dashboard.html
+++ b/src/inventario/templates/dashboard.html
@@ -1,4 +1,4 @@
-{% extends 'administracion/base.html' %}
+{% extends 'administración/base.html' %}
 
 {% block titulo %} Dashboard {% endblock %}
 

--- a/src/inventario/templates/ventas/listado_productos.html
+++ b/src/inventario/templates/ventas/listado_productos.html
@@ -1,0 +1,82 @@
+{% extends 'administración/base.html' %}
+
+{% block titulo %}Administrar productos{% endblock %}
+{% block contenido %}
+    <div class="container">
+        <div class="row">
+            <div class="container">
+                <h1>Administrar productos</h1>
+                <div class="card">
+                    <div class="card-body">
+                        Se presentan todos los productos en lista. Primero, muestra productos que no han sido publicados
+                        aún
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-striped">
+                                <thead>
+                                <tr>
+                                    <th>PK</th>
+                                    <th>Titulo</th>
+                                    <th>Autor</th>
+                                    <th>Editorial</th>
+                                    <th>Generos</th>
+                                    <th>Precio</th>
+                                    <th>Stock</th>
+                                    <th>Destacado</th>
+                                    <th>Publicado</th>
+                                    <th>Examinar</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {% for producto in productos %}
+                                    <tr>
+                                        <td>{{ producto.pk }}</td>
+                                        <td>{{ producto.titulo_es }}</td>
+                                        <td>{{ producto.autor }}</td>
+                                        <td>{{ producto.editorial }}</td>
+                                        <td>
+                                            {% if producto.genero %}
+                                                {% for genero in producto.genero.all %}
+                                                    <span class="badge rounded-pill bg-secondary">{{ genero.nombre }}</span>
+                                                {% endfor %}
+                                            {% else %}
+                                                <span class="badge rounded-pill bg-dark">No asignado</span>
+                                            {% endif %}
+                                        </td>
+                                        <td>{{ producto.precio }}</td>
+                                        <td>{{ producto.stock }}</td>
+                                        <td style="text-align: center;">
+                                <span class="badge rounded-pill
+                                        {% if producto.es_destacado %} bg-success {% else %} bg-danger {% endif %}">
+                                    <i class="fa {% if producto.es_destacado %}fa-check{% else %}fa-remove{% endif %}"></i>
+                                </span>
+                                        </td>
+                                        <td style="text-align: center;">
+                                <span class="badge rounded-pill
+                                        {% if producto.esta_publicado %} bg-success {% else %} bg-danger {% endif %}">
+
+                                    <i class="fa {% if producto.esta_publicado %}fa-check{% else %}fa-remove{% endif %}"></i>
+                                </span>
+                                        </td>
+                                        <td style="text-align: center;">
+                                            <a href="{% url 'ventas-actualizar-producto' producto.pk %}" class="btn btn-outline-primary">
+                                                <i class="fa fa-search"></i>
+                                            </a>
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {% include 'común/includes/paginación.html' %}
+
+        </div>
+    </div>
+{% endblock %}

--- a/src/inventario/urls.py
+++ b/src/inventario/urls.py
@@ -4,7 +4,8 @@ from .vistas_modelos.editorial import EditorialListView, EditorialCreateView, Ed
 from .vistas_modelos.pais import PaisListView, PaisCreateView, PaisUpdateView, PaisDeleteView
 from .vistas_modelos.genero import GeneroListView, GeneroCreateView, GeneroUpdateView, GeneroDeleteView
 from .vistas_modelos.autor import AutorListView, AutorCreateView, AutorUpdateView, AutorDeleteView
-from .vistas_modelos.producto import ProductoListView, ProductoUpdateView, ProductoCreateView, ProductoDeleteView
+from .vistas_modelos.producto import ProductoListView, ProductoUpdateView, ProductoCreateView, ProductoDeleteView, \
+    ActualizarProductoVentasView, VentasListadoProductosView
 from .views import DashboardView
 
 urlpatterns = [
@@ -41,4 +42,8 @@ urlpatterns = [
     path('eliminar-pais/<pk>/', PaisDeleteView.as_view(), name='eliminar-pais'),
     path('eliminar-editorial/<pk>/', EditorialDeleteView.as_view(), name='eliminar-editorial'),
     path('eliminar-otro-autor/<pk>/', OtrosAutoresDeleteView.as_view(), name='eliminar-otro-autor'),
+
+    # específicos de ventas
+    path('ventas-listado-productos', VentasListadoProductosView.as_view(), name='ventas-listado-productos'),
+    path('ventas-actualizar-producto/<pk>', ActualizarProductoVentasView.as_view(), name='ventas-actualizar-producto'),
 ]

--- a/src/inventario/vistas_modelos/producto.py
+++ b/src/inventario/vistas_modelos/producto.py
@@ -1,9 +1,13 @@
 from django.urls import reverse_lazy
-from django.views.generic import ListView
+from django.views.generic import ListView, UpdateView
+
+from artemangaweb.mixins import MensajeResultadoFormMixin
+from cuenta_usuario.enums.opciones import TipoUsuario
+from cuenta_usuario.restriccion import VistaRestringida
 
 from inventario.models import Producto
 from .vistas_genericas import CrearGenerico, ActualizarGenerico, EliminarGenerico
-from inventario.forms import ProductoBodegaForm
+from inventario.forms import ProductoBodegaForm, ActualizarProductoVentasForm
 
 
 class ProductoListView(ListView):
@@ -41,3 +45,21 @@ class ProductoCreateView(CrearGenerico):
 class ProductoDeleteView(EliminarGenerico):
     model = Producto
     success_url = reverse_lazy('listado-producto')
+
+
+class ActualizarProductoVentasView(VistaRestringida, MensajeResultadoFormMixin, UpdateView):
+    usuarios_permitidos = [TipoUsuario.ADMINISTRADOR, TipoUsuario.VENTAS]
+    template_name = 'CRUD/form_generico.html'
+    model = Producto
+    form_class = ActualizarProductoVentasForm
+    success_url = reverse_lazy('ventas-listado-productos')
+
+
+class VentasListadoProductosView(VistaRestringida, ListView):
+    usuarios_permitidos = [TipoUsuario.ADMINISTRADOR, TipoUsuario.VENTAS]
+    model = Producto
+    template_name = "ventas/listado_productos.html"
+    queryset = Producto.objects.all()
+    ordering = ['esta_publicado']
+    paginate_by = 10
+    context_object_name = 'productos'

--- a/src/templates/administración/base.html
+++ b/src/templates/administración/base.html
@@ -31,7 +31,7 @@
                 <li class="nav-item dropdown">
                     <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown">Ventas</a>
                     <div class="dropdown-menu">
-                        <a href="#" class="dropdown-item">Absolutamente nada</a>
+                        <a href="{% url 'ventas-listado-productos' %}" class="dropdown-item">Productos</a>
                     </div>
                 </li>
                 {% endif %}

--- a/src/templates/común/includes/paginación.html
+++ b/src/templates/común/includes/paginación.html
@@ -1,0 +1,19 @@
+<nav aria-label="Paginación">
+    {% if is_paginated %}
+        <ul class="pagination justify-content-center">
+            {% if page_obj.has_previous %}
+                <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Anterior</a></li>
+            {% endif %}
+
+            {% for i in paginator.page_range %}
+                <li class="page-item {% if page_obj.number == i %}active{% endif %}">
+                    <a class="page-link" href="?page={{ i }}">{{ i }}</a>
+                </li>
+            {% endfor %}
+
+            {% if page_obj.has_next %}
+                <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Siguiente</a></li>
+            {% endif %}
+        </ul>
+    {% endif %}
+</nav>


### PR DESCRIPTION
Agrega vistas para manejar estado de publicado y destacado de un producto. Tiré la wea que estaba haciendo y decidí hacer lo más sencillo primero, así que funciona igual que cualquier otro crud, pero sólo con esos campos.