### PR TITLE
fix: arregla subida de fotos en formulario de admin bodega

### DIFF
--- a/src/templates/administración/CRUD/form_generico.html
+++ b/src/templates/administración/CRUD/form_generico.html
@@ -6,7 +6,7 @@
     <div class="card">
         <div class="card-body">
             <h3>{{ titulo_pagina }}</h3>
-            <form role="form" method="post">
+            <form role="form" method="post" enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ form|crispy }}
                 <input type="submit" name="submit" value="Guardar" class="submit submitButton" />


### PR DESCRIPTION
faltaba el ``enctype`` en el formulario. Sin ese atributo, no se guardan datos en ``POST.files``

fixes: #121