### PR TITLE
Fix boton carrito

### DIFF
--- a/.github/workflows/okteto_crear.yml
+++ b/.github/workflows/okteto_crear.yml
@@ -1,7 +1,8 @@
 on:
     pull_request_target:
         branches:
-            - main
+            - master
+            - devel
 
 jobs:
     preview:

--- a/src/templates/web/catalogo_filtrado.html
+++ b/src/templates/web/catalogo_filtrado.html
@@ -27,4 +27,6 @@
         {% endif %}
         {% include 'común/includes/paginación.html' %}
     </div>
+
+{% include 'web/includes/js-snippets/sombra-cards.html' %}
 {% endblock %}

--- a/src/templates/web/includes/card-producto.html
+++ b/src/templates/web/includes/card-producto.html
@@ -4,7 +4,8 @@
 <div class="col-lg-3 col-md-6 col-sm-12">
     <div class="card h-100 border-0 position-relative">
         {% include 'web/includes/producto-tag.html' with producto=producto %}
-        <a class="card-block stretched-link text-decoration-none" href="{% url 'detalle-producto' producto.pk %}"></a>
+        <a style="z-index: 1" class="card-block stretched-link text-decoration-none"
+           href="{% url 'detalle-producto' producto.pk %}"></a>
         <img class="card-img-top" src="{{ producto.portada.url }}" alt="">
         <div class="card-body">
             <div class="container text-center">
@@ -24,7 +25,8 @@
                 {% endif %}
                 <div class="row justify-content-center">
                     <div class="col-3 p-2">
-                        <button type="button" onclick="agregarProducto({{ producto.pk }})" class="btn btn-warning">
+                        <button style="z-index: 1; position: relative" type="button"
+                                onclick="agregarProducto({{ producto.pk }})" class="btn btn-warning">
                             <i class="fa-solid fa-cart-plus"></i>
                         </button>
                     </div>

--- a/src/templates/web/includes/card-producto.html
+++ b/src/templates/web/includes/card-producto.html
@@ -2,7 +2,7 @@
 {% load humanize %}
 
 <div class="col-lg-3 col-md-6 col-sm-12">
-    <div class="card h-100 border-0 position-relative">
+    <div class="card h-100 border-0 position-relative rounded">
         {% include 'web/includes/producto-tag.html' with producto=producto %}
         <a style="z-index: 1" class="card-block stretched-link text-decoration-none"
            href="{% url 'detalle-producto' producto.pk %}"></a>

--- a/src/templates/web/includes/js-snippets/sombra-cards.html
+++ b/src/templates/web/includes/js-snippets/sombra-cards.html
@@ -1,0 +1,9 @@
+<script>
+    $(".card").hover(
+        function () {
+            $(this).addClass('shadow-sm').css('cursor', 'pointer');
+        }, function () {
+            $(this).removeClass('shadow-sm');
+        }
+    );
+</script>

--- a/src/templates/web/index.html
+++ b/src/templates/web/index.html
@@ -40,4 +40,7 @@
     {% endif %}
 
 </div>
+
+{% include 'web/includes/js-snippets/sombra-cards.html' %}
+
 {% endblock %}


### PR DESCRIPTION
Arregla la inhabilidad de apretar el carrito de compras en el catálogo cambiando el índice z (la altura) del objeto. Ahora está *encima* del resto de la card. También agrega una sombra sutil al pasar el mouse por las cards.

fixes #131 