### PR TITLE
fix: inicia el daemon de cron en producción

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -21,6 +21,9 @@ then
     echo "Base de datos inicializada"
 fi
 
+# arranca el daemon de cron para que realmente empiecen los cronjobs
+crond -l 0 -d 0 -L /home/website/media/logs/cron.log
+
 # elimina datos en la base de datos
 #python manage.py flush --no-input
 


### PR DESCRIPTION
Esto debería hacer de una vez por todas que sí se manden los correos de las notificaciones.

Ojo, esto no arregla #185, esos correos no se están ni encolando.