### PR TITLE
fix: corrige error al intentar comprar sin haber iniciado sesión antes

### DIFF
--- a/src/cuenta_usuario/models.py
+++ b/src/cuenta_usuario/models.py
@@ -38,7 +38,7 @@ class Usuario(AbstractUser):
     def generar_pass_temporal_empleados(self) -> str:
         primer_nombre = f"{self.primer_nombre.upper()[:2]}"
         primer_apellido = f"{self.primer_apellido.lower()[-2:]}"
-        fecha_registro = f"{self.date_joined[-2:]}"
+        fecha_registro = f"{self.date_joined.year}{self.date_joined.month}{self.date_joined.day}"
         return f"{primer_nombre}{primer_apellido}{fecha_registro}"
 
     def save(self, *args, **kwargs):

--- a/src/venta/views.py
+++ b/src/venta/views.py
@@ -110,7 +110,7 @@ class ElegirDireccionView(ImpedirSinRedireccionMixin, VistaRestringidaMixin, Tit
 
 class ConfirmarCompraView(ImpedirSinRedireccionMixin, VistaRestringidaMixin, View):
     usuarios_permitidos = VistaRestringidaMixin.todos_los_usuarios
-    paginas_permitidas = ['ver-carrito', 'crear-direccion']
+    paginas_permitidas = ['ver-carrito', 'crear-direccion', 'login']
     permission_denied_message = '¡Debe iniciar sesión o registrarse para realizar una compra!'
 
     def get(self, request):


### PR DESCRIPTION
Agrega login a las páginas permitidas como antecedente de ``confirmar-compra``.
Corrige la generación de contraseñas temporales para empleados, la fecha estaba siendo tratada como string y es en realidad una fecha.