### PR TITLE
Corrige error con editoriales en dropdown

### DIFF
--- a/src/artemangaweb/contexto_comun.py
+++ b/src/artemangaweb/contexto_comun.py
@@ -6,7 +6,7 @@ from catalogo.models import Oferta
 from django.db.models import Q
 
 def obtener_editoriales_y_categorias(request):
-    editoriales = Editorial.objects.filter(producto__stock__gte=1, producto__esta_publicado=True)[:8]
+    editoriales = Editorial.objects.all()
     categorias = Genero.objects.all()
     return {'editoriales': editoriales, 'categorias': categorias}
 


### PR DESCRIPTION
Estaba listando la misma editorial varias veces, una por cada producto que coincide. Mirar el sitio web para comprobar.